### PR TITLE
Add Mitotree (RSRS and rCRS) support to Haplogrep 3 (+Resolve conflicts for PR #2)

### DIFF
--- a/trees.json
+++ b/trees.json
@@ -61,4 +61,22 @@
     "version": "1.3",
     "url": "https://github.com/genepi/phylotree-fu-rcrs/releases/download/1.3/phylotree-fu-rcrs-1.3.zip"
   }]
+},{
+  "id": "mitotree-rsrs",
+  "latest": "2026.05.06",
+  "url": "https://github.com/genebygene/mitotree/",
+  "description": "FamilyTreeDNA Mitotree (RSRS Human mtDNA, non-commercial use only)",
+  "releases": [{
+    "version": "2026.05.06",
+    "url": "https://github.com/genebygene/mitotree/releases/download/2026.05.06/mitotree-rsrs-2026.05.06.zip"
+  }]
+},{
+  "id": "mitotree-rcrs",
+  "latest": "2026.05.06",
+  "url": "https://github.com/genebygene/mitotree/",
+  "description": "FamilyTreeDNA Mitotree (rCRS Human mtDNA, non-commercial use only)",
+  "releases": [{
+    "version": "2026.05.06",
+    "url": "https://github.com/genebygene/mitotree/releases/download/2026.05.06/mitotree-rcrs-2026.05.06.zip"
+  }]
 }]


### PR DESCRIPTION
This PR resolves the merge conflicts in PR #2.

Original PR: #2
Author: @goranrunfeldt

Changes:
- Merged latest main into the branch
- Resolved merge conflicts
- Preserved the original Mitotree additions